### PR TITLE
feat: universal build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -97,14 +97,14 @@ if [ ! -d "Unity-$unityversion" ]; then
   fi
 fi
 
-if [ ! -d "Steamworks.NET-Standalone_14.0.0" ]; then
+if [ ! -d "Steamworks.NET-Standalone_20.0.0" ]; then
   if confirm "Download Steamworks.NET (~2.5MB) from GitHub?"; then
-    curl -L https://github.com/rlabrecque/Steamworks.NET/releases/download/14.0.0/Steamworks.NET-Standalone_14.0.0.zip -o Steamworks.NET-Standalone_14.0.0.zip
-    verify Steamworks.NET-Standalone_14.0.0.zip 889417c79b52e7a33e67807aac21337c
-    unzip Steamworks.NET-Standalone_14.0.0.zip -d Steamworks.NET-Standalone_14.0.0
+    curl -L https://github.com/rlabrecque/Steamworks.NET/releases/download/20.0.0/Steamworks.NET-Standalone_20.0.0.zip -o Steamworks.NET-Standalone_20.0.0.zip
+    verify Steamworks.NET-Standalone_20.0.0.zip 96069c00e080acf9d4bc91d4cc9cff2c
+    unzip Steamworks.NET-Standalone_20.0.0.zip -d Steamworks.NET-Standalone_20.0.0
   fi
 
-  if [ ! -d "Steamworks.NET-Standalone_14.0.0" ]; then
+  if [ ! -d "Steamworks.NET-Standalone_20.0.0" ]; then
     echo "Steamworks.NET not found, exiting.."
     exit 1
   fi
@@ -150,7 +150,7 @@ cp -r $prefix/Resources/Data/Resources/* $prefix/Resources/
 rm $prefix/Resources/UnityPlayer.png
 
 cp vendor/depots/$depotid/$buildid/valheim_Data/Plugins/Steamworks.NET.txt $prefix/PlugIns/
-cp -r vendor/Steamworks.NET-Standalone_14.0.0/OSX-Linux-x64/steam_api.bundle $prefix/Plugins/
+cp -r vendor/Steamworks.NET-Standalone_20.0.0/OSX-Linux-x64/steam_api.bundle $prefix/Plugins/
 
 cp -r vendor/PlayFabParty-for-macOS_v1.7.16/PlayFabParty-for-macOS/PlayFabPartyMacOS.bundle $prefix/Plugins/party.bundle
 


### PR DESCRIPTION
This PR turns the build universal, supporting both Rosetta 2 and Apple Silicon, resolving #32.

Unfortunately, UnityPlayer is seemingly actively preventing OpenGL from being used on arm64, so this PR contains a binary patch to 'rectify' that.

> [!CAUTION]
> 
> This branch is no longer compatible with recent Valheim versions: the proposed workaround will likely need to be adjusted.

The native Apple Silicon build seems / feels a bit snappier to my untrained eye.

Things to figure out:

- [ ] Is patching `UnityPlayer.dylib` in this manner safe / a good idea?
- [ ] What are the implications of having to re-sign `UnityPlayer.dylib`?
- [ ] Does Steam cloud sync / loading work properly? (initially, all characters were gone 😱 )
- [ ] Does multiplayer work correctly? (have only tested single-player briefly)
- [ ] What are these graphical glitches in the sky? (see video below)
- [ ] Does Steamworks.NET.txt need updating? (left it as-is for now)

https://github.com/timkurvers/valheim-macos/assets/378235/e0c94cae-1a2a-412f-812f-501eb9773a3f