### PR TITLE
feat: support public test patch 0.217.27

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Valheim macOS
 
 [![Stable version](https://badgen.net/badge/Stable%20version/0.217.25/green)](https://valheim.com/news/patch-0-217-25/)
-[![Public Test version](https://badgen.net/badge/Public%20Test%20version/0.217.25/orange)](https://store.steampowered.com/news/app/892970/view/6688466724224306368)
+[![Public Test version](https://badgen.net/badge/Public%20Test%20version/0.217.27/orange)](https://store.steampowered.com/news/app/892970/view/3717217413243936519)
 
 ## Background
 

--- a/build.sh
+++ b/build.sh
@@ -140,6 +140,7 @@ cat skeleton/Valheim.app/Contents/Info.plist \
     | sed "s|\$appid|$appid|g" \
     | sed "s|\$unityhash|$unityhash|g" \
     | sed "s|\$unityversion|$unityversion|g" \
+    | sed "s|\$unityyear|${unityversion:0:4}|g" \
     | sed "s|\$version|$version|g" \
     > $prefix/Info.plist
 

--- a/build.sh
+++ b/build.sh
@@ -17,6 +17,8 @@ version="0.217.25"
 unityversion="2020.3.45f1"
 unityhash="660cd1701bd5"
 variant="macos_x64_nondevelopment_mono"
+steamworksversion="14.0.0"
+steamworkshash="889417c79b52e7a33e67807aac21337c"
 outdir="build"
 
 # Beta (public-test)
@@ -97,14 +99,14 @@ if [ ! -d "Unity-$unityversion" ]; then
   fi
 fi
 
-if [ ! -d "Steamworks.NET-Standalone_14.0.0" ]; then
+if [ ! -d "Steamworks.NET-Standalone_$steamworksversion" ]; then
   if confirm "Download Steamworks.NET (~2.5MB) from GitHub?"; then
-    curl -L https://github.com/rlabrecque/Steamworks.NET/releases/download/14.0.0/Steamworks.NET-Standalone_14.0.0.zip -o Steamworks.NET-Standalone_14.0.0.zip
-    verify Steamworks.NET-Standalone_14.0.0.zip 889417c79b52e7a33e67807aac21337c
-    unzip Steamworks.NET-Standalone_14.0.0.zip -d Steamworks.NET-Standalone_14.0.0
+    curl -L https://github.com/rlabrecque/Steamworks.NET/releases/download/$steamworksversion/Steamworks.NET-Standalone_$steamworksversion.zip -o Steamworks.NET-Standalone_$steamworksversion.zip
+    verify Steamworks.NET-Standalone_$steamworksversion.zip $steamworkshash
+    unzip Steamworks.NET-Standalone_$steamworksversion.zip -d Steamworks.NET-Standalone_$steamworksversion
   fi
 
-  if [ ! -d "Steamworks.NET-Standalone_14.0.0" ]; then
+  if [ ! -d "Steamworks.NET-Standalone_$steamworksversion" ]; then
     echo "Steamworks.NET not found, exiting.."
     exit 1
   fi
@@ -150,7 +152,7 @@ cp -r $prefix/Resources/Data/Resources/* $prefix/Resources/
 rm $prefix/Resources/UnityPlayer.png
 
 cp vendor/depots/$depotid/$buildid/valheim_Data/Plugins/Steamworks.NET.txt $prefix/PlugIns/
-cp -r vendor/Steamworks.NET-Standalone_14.0.0/OSX-Linux-x64/steam_api.bundle $prefix/Plugins/
+cp -r vendor/Steamworks.NET-Standalone_$steamworksversion/OSX-Linux-x64/steam_api.bundle $prefix/Plugins/
 
 cp -r vendor/PlayFabParty-for-macOS_v1.7.16/PlayFabParty-for-macOS/PlayFabPartyMacOS.bundle $prefix/Plugins/party.bundle
 

--- a/build.sh
+++ b/build.sh
@@ -24,12 +24,14 @@ outdir="build"
 # Beta (public-test)
 if [[ " $* " =~ " --beta " ]]; then
   branch="public-test"
-  buildid=12413229
+  buildid=12528422
   unset manifestid
-  version="0.217.25"
-  # unityversion="2020.3.45f1"
-  # unityhash="660cd1701bd5"
-  # variant="macos_x64_nondevelopment_mono"
+  version="0.217.27"
+  unityversion="2022.3.9f1"
+  unityhash="ea401c316338"
+  variant="macos_x64_player_nondevelopment_mono"
+  steamworksversion="20.2.0"
+  steamworkshash="6c8e7f5101176ed13d32cf704a4febe6"
   outdir="build-beta"
 fi
 

--- a/skeleton/Valheim.app/Contents/Info.plist
+++ b/skeleton/Valheim.app/Contents/Info.plist
@@ -7,7 +7,7 @@
     <key>CFBundleExecutable</key>
     <string>Valheim</string>
     <key>CFBundleGetInfoString</key>
-    <string>Valheim $version — Unity Player version $unityversion ($unityhash). (c) 2020 Unity Technologies ApS. All rights reserved.</string>
+    <string>Valheim $version — Unity Player version $unityversion ($unityhash). (c) $unityyear Unity Technologies ApS. All rights reserved.</string>
     <key>CFBundleIconFile</key>
     <string>Valheim.icns</string>
     <key>CFBundleIdentifier</key>


### PR DESCRIPTION
This adds support for newly released public test patch 0.217.27: https://store.steampowered.com/news/app/892970/view/3717217413243936519

As this is a major Unity engine + Valheim plugins upgrade, verify the following:

- [x] Steam integration (Steamworks 20.2)
- [x] Single-player (loaded up a locally hosted world)
- [ ] Multi-player (may require PlayFabParty update as `libparty.so` for Linux was modified)
- [x] Ensure the original / stable build still works