### PR TITLE
feat: support patch 0.217.28 for stable and beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Valheim macOS
 
-[![Stable version](https://badgen.net/badge/Stable%20version/0.217.25/green)](https://valheim.com/news/patch-0-217-25/)
-[![Public Test version](https://badgen.net/badge/Public%20Test%20version/0.217.27/orange)](https://store.steampowered.com/news/app/892970/view/3717217413243936519)
+[![Stable version](https://badgen.net/badge/Stable%20version/0.217.28/green)](https://store.steampowered.com/news/app/892970/view/3787024475499546363)
+[![Public Test version](https://badgen.net/badge/Public%20Test%20version/0.217.28/orange)](https://store.steampowered.com/news/app/892970/view/3787024475499546363)
 
 ## Background
 

--- a/build.sh
+++ b/build.sh
@@ -11,16 +11,16 @@ depotid=892971
 
 # Stable (public)
 branch="public"
-buildid=12413229
-manifestid=4749251671148241556
-version="0.217.25"
+buildid=12593117
+manifestid=8248830790758710826
+version="0.217.28"
 depotdownloaderversion="2.5.0"
 depotdownloaderhash="462442ad9973c6482be6a1a0af3aee60"
-unityversion="2020.3.45f1"
-unityhash="660cd1701bd5"
-variant="macos_x64_nondevelopment_mono"
-steamworksversion="14.0.0"
-steamworkshash="889417c79b52e7a33e67807aac21337c"
+unityversion="2022.3.12f1"
+unityhash="4fe6e059c7ef"
+variant="macos_x64_player_nondevelopment_mono"
+steamworksversion="20.2.0"
+steamworkshash="6c8e7f5101176ed13d32cf704a4febe6"
 playfabpartyversion="1.7.16"
 playfabpartyhash="95cd6814893d57abd63c19fb668d304c"
 outdir="build"
@@ -28,14 +28,9 @@ outdir="build"
 # Beta (public-test)
 if [[ " $* " =~ " --beta " ]]; then
   branch="public-test"
-  buildid=12528422
+  buildid=12593117
   unset manifestid
-  version="0.217.27"
-  unityversion="2022.3.9f1"
-  unityhash="ea401c316338"
-  variant="macos_x64_player_nondevelopment_mono"
-  steamworksversion="20.2.0"
-  steamworkshash="6c8e7f5101176ed13d32cf704a4febe6"
+  version="0.217.28"
   outdir="build-beta"
 fi
 


### PR DESCRIPTION
Regarding the PlayFabParty version, first I tried a multiplayer game with a windows pc which obviously had a correct PlayFabParty version, but everything worked with our current one. Next I did a little bit of investigation, took a look at the MD5 sums of the `libparty.so` that was getting downloaded by the DepotDownloader. The current stable depot (12593117) and the previous one (12528422) both have the identical file with the checksum of `b238f065f8f4c44b64d3ac2c55413adf`, which corresponds to [this release of PlayFabParty for Linux v1.7.14](https://github.com/PlayFab/PlayFabParty/releases/tag/v1.7.14-pr2). Since we have 1.7.16, I think we're fine with the current version by now (plus I can confirm that it works).

Closes #57.